### PR TITLE
Use Exception instead of SocketException for AllowNatTraversal function

### DIFF
--- a/BeaconLib/Beacon.cs
+++ b/BeaconLib/Beacon.cs
@@ -33,7 +33,7 @@ namespace BeaconLib
             {
                 udp.AllowNatTraversal(true);
             }
-            catch (SocketException ex)
+            catch (Exception ex)
             {
                 Debug.WriteLine("Error switching on NAT traversal: " + ex.Message);
             }

--- a/BeaconLib/Probe.cs
+++ b/BeaconLib/Probe.cs
@@ -42,7 +42,7 @@ namespace BeaconLib
             {
                 udp.AllowNatTraversal(true);
             }
-            catch (SocketException ex)
+            catch (Exception ex)
             {
                 Debug.WriteLine("Error switching on NAT traversal: " + ex.Message);
             }


### PR DESCRIPTION
Replace SocketException by Exception in Probe and Beacon ctor for support on frameworks with missing AllowNatTraversal function.

On older mono versions, creation of Probe fails due to exception:
Exception of type `System.MissingMethodException`: Method not found: 'System.Net.Sockets.UdpClient.AllowNatTraversal'
Currently only SocketException is catched, not MissingMethodException so it fails.

I assume this AllowNatTraversal is not mandatory for this library.
I don't know if automatic, please update also NuGet package once merged.