### PR TITLE
Catch unhandled exceptions in Probe background thread

### DIFF
--- a/BeaconLib/Probe.cs
+++ b/BeaconLib/Probe.cs
@@ -42,7 +42,7 @@ namespace BeaconLib
             {
                 udp.AllowNatTraversal(true);
             }
-            catch (SocketException ex)
+            catch (Exception ex)
             {
                 Debug.WriteLine("Error switching on NAT traversal: " + ex.Message);
             }
@@ -86,7 +86,15 @@ namespace BeaconLib
         {
             while (running)
             {
-                BroadcastProbe();
+                try
+                {
+                    BroadcastProbe();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+
                 waitHandle.WaitOne(2000);
                 PruneBeacons();
             }
@@ -137,7 +145,14 @@ namespace BeaconLib
 
         public void Dispose()
         {
-            Stop();
+            try
+            {
+                Stop();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex);
+            }
         }
     }
 }


### PR DESCRIPTION
The CLR allows most unhandled exceptions in threads to proceed naturally. In most cases this means that the unhandled exception causes the application to terminate. 

Added try-catch for BroadcastProbe to prevent whole process/application to terminate in case of temporary network not available throwing in some case Exception of type `System.Net.Sockets.SocketException`: Network is unreachable.

Please update nuget package (if not automatic) after merging, thanks.